### PR TITLE
fix: notify Slack for published book reports

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -5,6 +5,11 @@ on:
     workflows: ["Deploy VitePress site to Pages"]
     types: [completed]
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -15,49 +20,37 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Find the most recent merged PR with book-report label
-            const { data: prs } = await github.rest.pulls.list({
+            const deployedSha = context.payload.workflow_run.head_sha;
+            const { data: associatedPRs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'closed',
-              sort: 'updated',
-              direction: 'desc',
-              per_page: 10
+              commit_sha: deployedSha,
+              per_page: 100
             });
 
-            const bookReportPR = prs.find(pr =>
+            const bookReportPR = associatedPRs.find(pr =>
               pr.merged_at &&
-              pr.labels.some(l => l.name === 'book-report')
+              pr.merge_commit_sha === deployedSha &&
+              (pr.labels || []).some(l => l.name === 'book-report')
             );
 
             if (!bookReportPR) {
-              console.log('No recent book-report PR found.');
+              console.log(`No merged book-report PR found for deployed SHA ${deployedSha}.`);
               core.setOutput('found', 'false');
               return;
             }
 
-            // NEW: Verify this deployment is actually FOR this PR
-            const deployedSha = context.payload.workflow_run.head_sha;
-            if (bookReportPR.merge_commit_sha !== deployedSha) {
-              console.log(`Deployed SHA (${deployedSha}) does not match PR Merge SHA (${bookReportPR.merge_commit_sha}). Skipping.`);
-              core.setOutput('found', 'false');
-              return;
-            }
-
-            // Get user profile to fetch display name
             const { data: userProfile } = await github.rest.users.getByUsername({
               username: bookReportPR.user.login
             });
             const authorName = userProfile.name || bookReportPR.user.login;
 
-            // Extract book title from PR title: feat: add book report 'Title'
             let cleanTitle = bookReportPR.title;
             const match = bookReportPR.title.match(/'(.*?)'/);
             if (match) {
               cleanTitle = match[1];
             } else {
-               // Fallback: try to strip conventional commit prefix if no quotes
-               cleanTitle = cleanTitle.replace(/^(feat|fix|chore).*?:\s*/, '').trim();
+              cleanTitle = cleanTitle.replace(/^(feat|fix|chore).*?:\s*/, '').trim();
             }
 
             core.setOutput('found', 'true');
@@ -65,84 +58,148 @@ jobs:
             core.setOutput('pr_title', cleanTitle);
             core.setOutput('pr_author', authorName);
             core.setOutput('pr_url', bookReportPR.html_url);
-            core.setOutput('pr_body', bookReportPR.body || '');
             core.setOutput('pr_head_ref', bookReportPR.head.ref);
 
       - name: Parse Book Report Content
         if: steps.find_pr.outputs.found == 'true'
         id: parse
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          PR_TITLE: ${{ steps.find_pr.outputs.pr_title }}
+          PR_AUTHOR: ${{ steps.find_pr.outputs.pr_author }}
+          PR_HEAD_REF: ${{ steps.find_pr.outputs.pr_head_ref }}
         with:
           script: |
-            const prBody = `${{ steps.find_pr.outputs.pr_body }}`;
-            const prHeadRef = `${{ steps.find_pr.outputs.pr_head_ref }}`;
-            const prNumber = `${{ steps.find_pr.outputs.pr_number }}`;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const fallbackTitle = process.env.PR_TITLE || '';
+            const fallbackAuthor = process.env.PR_AUTHOR || '';
+            const prHeadRef = process.env.PR_HEAD_REF || '';
 
-            // Extract issue number from branch name "book-report/issue-123"
-            let issueNumber = null;
-            const branchMatch = prHeadRef.match(/issue-(\d+)/);
-            if (branchMatch) issueNumber = branchMatch[1];
-
-            if (!issueNumber) {
-              console.log('No linked issue found from branch.');
-              core.setOutput('page_url', '');
-              core.setOutput('objective', 'なし');
-              core.setOutput('takeaways', 'なし');
-              core.setOutput('application', 'なし');
-              core.setOutput('positive', 'なし');
-              core.setOutput('negative', 'なし');
-              core.setOutput('recommend', 'なし');
-              return;
-            }
-
-            const { data: issue } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber
-            });
-
-            const body = issue.body;
-
-            function extract(label) {
-              const regex = new RegExp("### " + label + "[^\\n]*\\n+([\\s\\S]*?)(?=(?:###|$))");
-              const m = body.match(regex);
-              return m ? m[1].trim() : 'なし';
-            }
-
-            // Get files from PR to find the book report path
             const { data: files } = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber
+              pull_number: prNumber,
+              per_page: 100
             });
+
             const reportFile = files.find(f => f.filename.startsWith('docs/knowledge_base/book_reports/') && f.filename.endsWith('.md'));
             let pageUrl = '';
+            let report = null;
             if (reportFile) {
               const relativePath = reportFile.filename.replace(/^docs\//, '').replace(/\.md$/, '.html');
               pageUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/${relativePath}`;
+
+              const { data: content } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: reportFile.filename,
+                ref: context.payload.workflow_run.head_sha
+              });
+
+              if (!Array.isArray(content) && content.type === 'file' && content.content) {
+                const markdown = Buffer.from(content.content, content.encoding || 'base64').toString('utf8');
+                report = parseReportMarkdown(markdown, fallbackTitle, fallbackAuthor);
+              }
             }
 
-            const objective = extract('読む前の目的');
-            const takeaways = extract('得られた知識');
-            const application = extract('実務における活用');
-            const positive = extract('良かった点');
-            const negative = extract('難しかった点・合わなかった点');
-            const recommend = extract('💡 どんな人におすすめ？');
+            if (!report) {
+              report = await parseIssueFallback(prHeadRef, fallbackTitle, fallbackAuthor);
+            }
 
-            core.setOutput('objective', objective);
-            core.setOutput('takeaways', takeaways);
-            core.setOutput('application', application);
-            core.setOutput('positive', positive);
-            core.setOutput('negative', negative);
-            core.setOutput('recommend', recommend);
+            core.setOutput('report_title', report.title || fallbackTitle);
+            core.setOutput('report_author', report.author || fallbackAuthor);
+            core.setOutput('objective', report.objective || 'なし');
+            core.setOutput('takeaways', report.takeaways || 'なし');
+            core.setOutput('application', report.application || 'なし');
+            core.setOutput('positive', report.positive || 'なし');
+            core.setOutput('negative', report.negative || 'なし');
+            core.setOutput('recommend', report.recommend || 'なし');
             core.setOutput('page_url', pageUrl);
+
+            function parseReportMarkdown(markdown, fallbackTitle, fallbackAuthor) {
+              return {
+                title: frontmatterValue(markdown, 'title') || fallbackTitle,
+                author: frontmatterValue(markdown, 'author') || fallbackAuthor,
+                objective: sectionValue(markdown, '読む前の目的'),
+                takeaways: sectionValue(markdown, '得られた知識'),
+                application: sectionValue(markdown, '実務における活用'),
+                positive: sectionValue(markdown, '良かった点'),
+                negative: sectionValue(markdown, '難しかった点・合わなかった点'),
+                recommend: sectionValue(markdown, 'どんな人におすすめ')
+              };
+            }
+
+            async function parseIssueFallback(prHeadRef, fallbackTitle, fallbackAuthor) {
+              const branchMatch = prHeadRef.match(/issue-(\d+)/);
+              if (!branchMatch) {
+                console.log('No report Markdown or linked issue found.');
+                return { title: fallbackTitle, author: fallbackAuthor };
+              }
+
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: branchMatch[1]
+              });
+              const body = issue.body || '';
+
+              return {
+                title: issueSectionValue(body, '書籍名') || fallbackTitle,
+                author: fallbackAuthor,
+                objective: issueSectionValue(body, '読む前の目的'),
+                takeaways: issueSectionValue(body, '得られた知識'),
+                application: issueSectionValue(body, '実務における活用'),
+                positive: issueSectionValue(body, '良かった点'),
+                negative: issueSectionValue(body, '難しかった点・合わなかった点'),
+                recommend: issueSectionValue(body, '💡 どんな人におすすめ？')
+              };
+            }
+
+            function frontmatterValue(markdown, key) {
+              const frontmatter = markdown.match(/^---\n([\s\S]*?)\n---/);
+              if (!frontmatter) return '';
+              const line = frontmatter[1].match(new RegExp(`^${escapeRegExp(key)}:\\s*(.*)$`, 'm'));
+              if (!line) return '';
+              return line[1].trim().replace(/^['"]|['"]$/g, '');
+            }
+
+            function sectionValue(markdown, label) {
+              const lines = markdown.split(/\r?\n/u);
+              const chunks = [];
+              let capturing = false;
+
+              for (const line of lines) {
+                if (/^##\s+/u.test(line)) {
+                  if (capturing) break;
+                  capturing = line.replace(/^##\s+/u, '').includes(label);
+                  continue;
+                }
+                if (capturing) {
+                  if (/^---\s*$/u.test(line)) break;
+                  chunks.push(line);
+                }
+              }
+
+              return chunks.join('\n').trim() || 'なし';
+            }
+
+            function issueSectionValue(body, label) {
+              const regex = new RegExp(`### ${escapeRegExp(label)}[^\\n]*\\n+([\\s\\S]*?)(?=(?:###|$))`, 'u');
+              const match = body.match(regex);
+              return match ? match[1].trim() : 'なし';
+            }
+
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
 
       - name: Send Slack Notification
         if: steps.find_pr.outputs.found == 'true'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          PR_TITLE: ${{ steps.find_pr.outputs.pr_title }}
-          PR_AUTHOR: ${{ steps.find_pr.outputs.pr_author }}
+          PR_TITLE: ${{ steps.parse.outputs.report_title }}
+          PR_AUTHOR: ${{ steps.parse.outputs.report_author }}
           PAGE_URL: ${{ steps.parse.outputs.page_url }}
           OBJECTIVE: ${{ steps.parse.outputs.objective }}
           TAKEAWAYS: ${{ steps.parse.outputs.takeaways }}
@@ -182,10 +239,14 @@ jobs:
           EOF
           )
 
-          jq -n \
+          SLACK_RESPONSE=$(jq -n \
             --arg text "$MESSAGE" \
-            '{channel: "#random", username: "BookRepo Bot", icon_emoji: ":books:", text: $text}' | \
-            curl -X POST "$SLACK_WEBHOOK" \
+            '{text: $text}' | \
+            curl --fail-with-body -sS -X POST "$SLACK_WEBHOOK" \
               -H 'Content-type: application/json' \
-              --data @-
+              --data @-)
 
+          if [ "$SLACK_RESPONSE" != "ok" ]; then
+            echo "Unexpected Slack webhook response."
+            exit 1
+          fi

--- a/.github/workflows/slack-report-notification-design.md
+++ b/.github/workflows/slack-report-notification-design.md
@@ -1,0 +1,31 @@
+# Slackレポート公開通知 設計書
+
+## 目的
+
+GitHub Pagesへ公開された書籍レポートを、Slackの公開チャンネルへ自動通知する。
+
+## 対象範囲
+
+- 対象: `.github/workflows/notify-slack.yml`
+- 対象外: Slack申請フロー、GitHub Pagesのビルド、旧Issue作成導線の廃止
+
+## 主要な処理の流れ
+
+1. `Deploy VitePress site to Pages` の成功を `workflow_run` で受ける。
+2. `workflow_run.head_sha` に紐づくPRを取得する。
+3. `book-report` ラベル付き、かつ `merge_commit_sha` が一致するPRだけを通知対象にする。
+4. PR内の `docs/knowledge_base/book_reports/*.md` を同じSHAから取得する。
+5. Markdownのfrontmatterと見出しから通知本文を作る。
+6. `SLACK_WEBHOOK` に投稿する。投稿先チャンネルはWebhookの向き先で管理する。
+7. Slack webhookがHTTPエラー、または `ok` 以外を返した場合はworkflowを失敗させる。
+
+## 変更するファイル
+
+- `.github/workflows/notify-slack.yml`
+- `tests/workflows/notify-slack.test.ts`
+
+## 確認方法
+
+- `npx tsx --test tests/workflows/notify-slack.test.ts`
+- `npm test`
+- `npm run docs:build`

--- a/tests/workers/slack-book-gateway-http.test.ts
+++ b/tests/workers/slack-book-gateway-http.test.ts
@@ -324,12 +324,14 @@ describe("slack-book-gateway HTTP entrypoints and state transitions", () => {
     await ctx.waitForWaitUntil();
 
     const prCall = calls.findGitHub("/repos/Saitekiinc-com/saiteki-study-doc/pulls", "POST");
+    const labelsCall = calls.findGitHub("/repos/Saitekiinc-com/saiteki-study-doc/issues/231/labels", "POST");
     const updateCall = calls.findSlack("chat.update");
     const nextState = firstActionState(updateCall.body.blocks, env.BOOK_PURCHASE_REQUESTS);
     const historyCall = calls.findSlack("chat.postMessage");
 
     assert.strictEqual(response.status, 200);
     assert.strictEqual(prCall.body.title, "feat: add book report for リーダブルコード");
+    assert.deepStrictEqual(labelsCall.body.labels, ["book-report"]);
     assert.strictEqual(nextState.status, "report_review_waiting");
     assert.strictEqual(nextState.prNumber, 231);
     assert.match(historyCall.body.text, /https:\/\/github\.com\/Saitekiinc-com\/saiteki-study-doc\/pull\/231/u);

--- a/tests/workers/slack-book-gateway-test-helpers.ts
+++ b/tests/workers/slack-book-gateway-test-helpers.ts
@@ -123,6 +123,9 @@ export function installFetchMock(options: { failGitHubBlob?: boolean; pinError?:
           head: { ref: "book-report/slack-test" }
         });
       }
+      if (githubPath === "/repos/Saitekiinc-com/saiteki-study-doc/issues/231/labels" && method === "POST") {
+        return jsonResponse([{ name: "book-report" }]);
+      }
       if (githubPath === "/repos/Saitekiinc-com/saiteki-study-doc/pulls/231" && method === "PATCH") {
         return jsonResponse({
           number: 231,

--- a/tests/workflows/notify-slack.test.ts
+++ b/tests/workflows/notify-slack.test.ts
@@ -1,16 +1,119 @@
-import { test, describe } from 'node:test';
+import { describe, test } from 'node:test';
 import assert from 'node:assert';
 
-// テストのために notify-slack.yml からロジックを抽出
-// 本来は共通モジュール化すべきですが、Workflow内ロジックの単体テストとしてここに記述します
-function extract(body: string, label: string): string {
-  const regex = new RegExp("### " + label + "[^\\n]*\\n+([\\s\\S]*?)(?=(?:###|$))");
-  const m = body.match(regex);
-  return m ? m[1].trim() : 'なし';
+type ReportNotificationFields = {
+  title: string;
+  author: string;
+  objective: string;
+  takeaways: string;
+  application: string;
+  positive: string;
+  negative: string;
+  recommend: string;
+};
+
+function parseReportMarkdown(markdown: string, fallbackTitle: string, fallbackAuthor: string): ReportNotificationFields {
+  return {
+    title: frontmatterValue(markdown, 'title') || fallbackTitle,
+    author: frontmatterValue(markdown, 'author') || fallbackAuthor,
+    objective: sectionValue(markdown, '読む前の目的'),
+    takeaways: sectionValue(markdown, '得られた知識'),
+    application: sectionValue(markdown, '実務における活用'),
+    positive: sectionValue(markdown, '良かった点'),
+    negative: sectionValue(markdown, '難しかった点・合わなかった点'),
+    recommend: sectionValue(markdown, 'どんな人におすすめ')
+  };
+}
+
+function parseIssueBody(body: string, fallbackTitle: string, fallbackAuthor: string): ReportNotificationFields {
+  return {
+    title: issueSectionValue(body, '書籍名') || fallbackTitle,
+    author: fallbackAuthor,
+    objective: issueSectionValue(body, '読む前の目的'),
+    takeaways: issueSectionValue(body, '得られた知識'),
+    application: issueSectionValue(body, '実務における活用'),
+    positive: issueSectionValue(body, '良かった点'),
+    negative: issueSectionValue(body, '難しかった点・合わなかった点'),
+    recommend: issueSectionValue(body, '💡 どんな人におすすめ？')
+  };
+}
+
+function frontmatterValue(markdown: string, key: string): string {
+  const frontmatter = markdown.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatter) return '';
+  const line = frontmatter[1].match(new RegExp(`^${escapeRegExp(key)}:\\s*(.*)$`, 'm'));
+  if (!line) return '';
+  return line[1].trim().replace(/^['"]|['"]$/g, '');
+}
+
+function sectionValue(markdown: string, label: string): string {
+  const lines = markdown.split(/\r?\n/u);
+  const chunks: string[] = [];
+  let capturing = false;
+
+  for (const line of lines) {
+    if (/^##\s+/u.test(line)) {
+      if (capturing) break;
+      capturing = line.replace(/^##\s+/u, '').includes(label);
+      continue;
+    }
+    if (capturing) {
+      if (/^---\s*$/u.test(line)) break;
+      chunks.push(line);
+    }
+  }
+
+  return chunks.join('\n').trim() || 'なし';
+}
+
+function issueSectionValue(body: string, label: string): string {
+  const regex = new RegExp(`### ${escapeRegExp(label)}[^\\n]*\\n+([\\s\\S]*?)(?=(?:###|$))`, 'u');
+  const match = body.match(regex);
+  return match ? match[1].trim() : 'なし';
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 describe('Slack 通知コンテンツの抽出', () => {
-    const sampleBody = `
+  const sampleMarkdown = `---
+title: "AI時代に強い質問力"
+author: 杉本光一
+issue_url: https://example.com/thread
+date: 2026-05-26
+---
+
+# AI時代に強い質問力
+
+*   **Original Source**: [Slack thread](https://example.com/thread)
+*   **投稿者**: 杉本光一
+*   **書籍の著者**: マツダミヒロ
+
+---
+
+## 🎯 読む前の目的
+質問力を高めたい
+
+## 💡 得られた知識・気づき
+良い質問は人生を変える
+
+## 🛠 実務における活用
+チームでの1on1に使う
+
+## 👍 良かった点・学び
+実例が多くて分かりやすい
+
+## 👎 難しかった点・合わなかった点
+特になし
+
+## 👤 どんな人におすすめ？
+リーダー層
+
+---
+`;
+
+  const sampleIssueBody = `
 ### 書籍名
 AI時代に強い質問力
 
@@ -36,29 +139,35 @@ AI時代に強い質問力
 リーダー層
 `;
 
-    test('"読む前の目的" が正しく抽出されること', () => {
-        const result = extract(sampleBody, '読む前の目的');
-        assert.strictEqual(result, '質問力を高めたい');
-    });
+  test('Slack由来のMarkdownから通知項目を抽出できること', () => {
+    const result = parseReportMarkdown(sampleMarkdown, 'fallback title', 'fallback author');
 
-    test('"得られた知識" が正しく抽出されること', () => {
-        const result = extract(sampleBody, '得られた知識');
-        assert.strictEqual(result, '良い質問は人生を変える');
-    });
+    assert.strictEqual(result.title, 'AI時代に強い質問力');
+    assert.strictEqual(result.author, '杉本光一');
+    assert.strictEqual(result.objective, '質問力を高めたい');
+    assert.strictEqual(result.takeaways, '良い質問は人生を変える');
+    assert.strictEqual(result.application, 'チームでの1on1に使う');
+    assert.strictEqual(result.positive, '実例が多くて分かりやすい');
+    assert.strictEqual(result.negative, '特になし');
+    assert.strictEqual(result.recommend, 'リーダー層');
+  });
 
-     test('"難しかった点・合わなかった点" が正しく抽出されること', () => {
-        const result = extract(sampleBody, '難しかった点・合わなかった点');
-        assert.strictEqual(result, '特になし');
-    });
+  test('Markdownにない値はfallbackまたはなしになること', () => {
+    const result = parseReportMarkdown('# タイトルだけ', 'fallback title', 'fallback author');
 
-    test('"💡 どんな人におすすめ？" が正しく抽出されること', () => {
-        // 注: YAML ではラベルとして '💡 どんな人におすすめ？' を使用している
-        const result = extract(sampleBody, '💡 どんな人におすすめ？');
-        assert.strictEqual(result, 'リーダー層');
-    });
+    assert.strictEqual(result.title, 'fallback title');
+    assert.strictEqual(result.author, 'fallback author');
+    assert.strictEqual(result.objective, 'なし');
+  });
 
-    test('存在しないフィールドには "なし" を返すこと', () => {
-        const result = extract(sampleBody, '存在しないフィールド');
-        assert.strictEqual(result, 'なし');
-    });
+  test('旧Issue本文からも通知項目を抽出できること', () => {
+    const result = parseIssueBody(sampleIssueBody, 'fallback title', 'fallback author');
+
+    assert.strictEqual(result.title, 'AI時代に強い質問力');
+    assert.strictEqual(result.author, 'fallback author');
+    assert.strictEqual(result.objective, '質問力を高めたい');
+    assert.strictEqual(result.takeaways, '良い質問は人生を変える');
+    assert.strictEqual(result.negative, '特になし');
+    assert.strictEqual(result.recommend, 'リーダー層');
+  });
 });

--- a/workers/slack-book-gateway/README.md
+++ b/workers/slack-book-gateway/README.md
@@ -100,12 +100,13 @@ npx wrangler secret put SLACK_BOT_TOKEN --config workers/slack-book-gateway/wran
 npx wrangler secret put GITHUB_TOKEN --config workers/slack-book-gateway/wrangler.jsonc
 ```
 
-`GITHUB_TOKEN` には、書籍レポートMarkdown用ブランチとPRを作成し、確認後にPRをマージできる権限が必要です。
+`GITHUB_TOKEN` には、書籍レポートMarkdown用ブランチとPRを作成し、PRへ `book-report` ラベルを付与し、確認後にPRをマージできる権限が必要です。
 
 Fine-grained tokenの場合の目安:
 
 - Repository contents: Read and write
 - Pull requests: Read and write
+- Issues: Read and write
 
 Classic tokenの場合は対象リポジトリに書き込みできる `repo` 相当の権限が必要です。
 

--- a/workers/slack-book-gateway/src/github.ts
+++ b/workers/slack-book-gateway/src/github.ts
@@ -81,6 +81,8 @@ export async function createBookReportPullRequest(
     })
   });
 
+  await addLabelsToPullRequest(env, pullRequest.number, ["book-report"]);
+
   return {
     ...pullRequest,
     reportPath
@@ -158,6 +160,13 @@ export async function updateBookReportPullRequest(env: Env, report: BookReportIn
     body: JSON.stringify({
       title: `feat: add book report for ${report.bookTitle}`
     })
+  });
+}
+
+async function addLabelsToPullRequest(env: Env, pullRequestNumber: number, labels: string[]): Promise<void> {
+  await githubRequest(env, `/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/issues/${pullRequestNumber}/labels`, {
+    method: "POST",
+    body: JSON.stringify({ labels })
   });
 }
 

--- a/workers/slack-book-gateway/src/slack-public-report-notification-design.md
+++ b/workers/slack-book-gateway/src/slack-public-report-notification-design.md
@@ -1,0 +1,30 @@
+# Slack由来レポートPR通知連携 設計書
+
+## 目的
+
+Slackから提出された書籍レポートPRを、GitHub Actionsの公開通知対象に含める。
+
+## 対象範囲
+
+- 対象: `workers/slack-book-gateway/src/github.ts`
+- 対象外: Slackの状態遷移、レポートMarkdownの項目、PRマージ処理
+
+## 主要な処理の流れ
+
+1. Slackのレポート提出から書籍レポートMarkdownを作る。
+2. `docs/knowledge_base/book_reports/*.md` を含むPRを作る。
+3. 作成したPRに `book-report` ラベルを付ける。
+4. 上長がSlackで完了ボタンを押すと、既存処理でPRをマージする。
+5. Pages公開後、`.github/workflows/notify-slack.yml` が `book-report` ラベル付きPRとして通知する。
+
+## 変更するファイル
+
+- `workers/slack-book-gateway/src/github.ts`
+- `workers/slack-book-gateway/README.md`
+- `tests/workers/slack-book-gateway-http.test.ts`
+- `tests/workers/slack-book-gateway-test-helpers.ts`
+
+## 確認方法
+
+- `npx tsx --test tests/workers/slack-book-gateway-http.test.ts tests/workers/slack-book-gateway-report-edit.test.ts`
+- `npx wrangler deploy --dry-run --config workers/slack-book-gateway/wrangler.jsonc`


### PR DESCRIPTION
## 概要
- Slack Gateway で作成する書籍レポートPRに `book-report` ラベルを自動付与
- `notify-slack.yml` を更新し、Pages デプロイ SHA に紐づくPRだけを通知対象に変更
- 通知本文はPR内の `docs/knowledge_base/book_reports/*.md` を同じSHAから読み、frontmatter と見出しから組み立てるように変更
- 旧Issue由来の本文抽出はフォールバックとして維持
- Slack webhook のHTTPエラーや `ok` 以外の応答をworkflow失敗として検知
- 関連テスト、設計書、Worker READMEのToken権限説明を更新

## テスト結果
- `npx tsx --test tests/workers/slack-book-gateway-http.test.ts tests/workers/slack-book-gateway-report-edit.test.ts tests/workflows/notify-slack.test.ts`
- `npm test`
- `npm run docs:build`
- `npx wrangler deploy --dry-run --config workers/slack-book-gateway/wrangler.jsonc`
- `git diff --check`
- `notify-slack.yml` YAML parse + github-script syntax check

## ブランチ戦略
- base: `main`
- working: `codex/slack-public-report-notification`
- Slack Gateway側のラベル付与と通知Workflow側の参照ロジックは同じ公開通知導線のため、今回は1PRで扱います。

## リスク / フォローアップ
- `SLACK_WEBHOOK` が実際に `C09Q1KNL2P8` を向いているかは、マージ後のlive canaryで確認が必要です。
- Worker本番 `GITHUB_TOKEN` に `Issues: Read and write` が付いていることを確認してください。
- `workflow_run` のrerunでは同じSHAの重複通知余地があります。今回の範囲では既存挙動として残しています。